### PR TITLE
Modify the plugin name that adds to a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 # How to use
-Add `iceberg-hyper` to `plugins` in `~/.hyper.js`.
+Add `hyper-iceberg` to `plugins` in `~/.hyper.js`.
 
 
 # Special thanks


### PR DESCRIPTION
When adding `iceberg-hyper`, the following error occurred. I think `hyper-iceberg` correctly.

> ```
> Trace:
>   Error: https://registry.yarnpkg.com/iceberg-hyper: Not found
> ```
> ~/.hyper_plugins/yarn-error.log
